### PR TITLE
Possibility to specify several concat configurations

### DIFF
--- a/.gsk/pipe/js/concat.js
+++ b/.gsk/pipe/js/concat.js
@@ -13,22 +13,7 @@ var uglify    = require('gulp-uglify');
 var bs        = require('browser-sync');
 var err       = require('../../tools/errcb');
 var ENV       = require('../../tools/env');
-
-// You may want to specify the files order in _config.json_, via the following
-// attribute: `ENV.js.src`
-// Otherwise files will be concatenated in alphabetical order, starting with
-// _lib_ folder
-var SRC  = [
-  path.join(ENV.js['src-dir'], 'lib', '**', '*'),
-  path.join(ENV.js['src-dir'], '**', '*')
-];
-if(ENV.js.src) {
-  SRC = ENV.js.src.map(function(jsfile) {
-    return path.resolve('.', path.normalize(jsfile));
-  });
-}
-
-var DEST = ENV.js['dest-dir'];
+var merge     = require('merge-stream');
 
 // TASK DEFINITION
 // ----------------------------------------------------------------------------
@@ -36,14 +21,59 @@ var DEST = ENV.js['dest-dir'];
 // ----------------------------------------------------------------------------
 // Gère toutes les actions d'assemblage JavaScript
 gulp.task('js', 'Concatenate JS files into build folder.', ['test:js'], function () {
-  return gulp.src(SRC)
-    .pipe(plumber({ errorHandler: err }))
-    .pipe(sourcemap.init())
-    .pipe(concat(ENV.js.filename))
-    .pipe(gif(ENV.all.optimize, uglify()))
-    .pipe(sourcemap.write('.'))
-    .pipe(gulp.dest(DEST))
-    .pipe(bs.stream());
+
+  // You may want to specify the files order in _config.json_, via the following
+  // attribute: `ENV.js.files`
+  // ```
+  // "files"    : [{
+  //     "src"  : "toto.js",
+  //     "dest" : "toto.js"
+  //   },{
+  //     "src" : [
+  //       "lib/**/*",
+  //       "tutu.js"
+  //     ],
+  //     "dest" : "tutu.js"
+  //   }]
+  // ```
+  // Otherwise files will be concatenated in alphabetical order, starting with
+  // _lib_ folder
+  var FILES = ENV.js.files;
+  if(!FILES) {
+    FILES = [{
+      src: [
+        path.join(ENV.js['src-dir'], 'lib', '**', '*'),
+        path.join(ENV.js['src-dir'], '**', '*')
+      ],
+      dest: ENV.js.filename
+    }];
+
+  // set source paths as absolute
+  } else {
+    FILES.map(function(file) {
+      if(!Array.isArray(file.src)) {
+        file.src = [file.src];
+      }
+      file.src = file.src.map(function(src) {
+        return path.join(ENV.js['src-dir'], src);
+      });
+      return file;
+    });
+  }
+
+  var DEST = ENV.js['dest-dir'];
+
+  return merge.apply(this, FILES.map(function(file) {
+    return gulp.src(file.src)
+      .pipe(plumber({ errorHandler: err }))
+      .pipe(sourcemap.init())
+      .pipe(concat(file.dest))
+      .pipe(gif(ENV.all.optimize, uglify()))
+      .pipe(sourcemap.write('.'))
+      .pipe(gulp.dest(DEST))
+      .pipe(bs.stream());
+  }));
+
 }, {
   options: {
     optimize : 'Optimize for production.',

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "gulp-util": "3.0.6",
     "lazypipe": "1.0.1",
     "jquery": "3.0.0",
+    "merge-stream": "1.0.0",
     "require-dir": "0.3.0",
     "run-sequence": "1.1.4",
     "slick-carousel": "1.6.0",


### PR DESCRIPTION
  ```
  "js" : {
    "src-dir"  : "./src/js",
    "dest-dir" : "./build/js",
    "engine"   : "concat",
    "files"    : [{
        "src"  : "toto.js",
        "dest" : "toto.js"
      },{
        "src" : [
          "lib/**/*",
          "tutu.js"
        ],
        "dest" : "tutu.js"
      }]
    }
  ```