### PR TITLE
[FIX] Webpack entries array

### DIFF
--- a/.gsk/webpack-config.js
+++ b/.gsk/webpack-config.js
@@ -10,12 +10,12 @@ const DEST = ENV.js['dest-dir'];
 var glob = require('glob');
 
 // Get collection of entries files from config.js
-let entries = {};
+let entries = [];
 
 let files = glob.sync(path.join(SRC, '*.js'));
 
 for (const file of files) {
-  entries[path.basename(file, '.js')] = file;
+  entries.push(file);
 }
 
 


### PR DESCRIPTION
Webpack attend un tableau, et non un objet {file: 'path', file2: 'path2'}

Il y avait un soucis de compilation, seul le premier fichier était inclus dans le fichier final.