### PR TITLE
Bower

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,0 +1,3 @@
+{
+  "directory" : "build/vendor"
+}

--- a/.gsk/docs/js/webpack.md
+++ b/.gsk/docs/js/webpack.md
@@ -41,6 +41,11 @@ $ npm i jquery,underscore,moment --save
 Pour les utiliser, vous pouvez soit utiliser la fonction `require` des modules
 CommonJS, soit la syntax `import` des modules ES2015.
 
+#### solution bis : via bower
+
+Bower est le gestionnaire de dépendance front là où npm concerne beaucoup les projets back end via node. Pour installer une dépendance bower, utilisez la commande `bower install package --save`.
+Par défaut la librairie téléchargée se situera dans le dossier `build/vendor`
+
 ### Babel et ES2015
 
 Par defaut, webpack utilise [Babel](http://babeljs.io/) pour transpiler en


### PR DESCRIPTION
Ajout des dépendances bower dans le dossier build/vendor. Il est préférable d'installer les dépendances front via bower là ou npm est plus utilisé dans le développement back end via node