### PR TITLE
Run "bundle install" only if a gemfile is available

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,8 @@ WORKDIR /usr/src/app
 COPY . /usr/src/app
 
 RUN npm install
-RUN bundle install
+# Run bundle command only if there is a gemfile available
+RUN if [ -f "Gemfile" ]; then bundle install; fi
 
 # Add node_modules
 ENV PATH "$PATH:/usr/src/app/node_modules/.bin"


### PR DESCRIPTION
When creating docker container with the latest version of the GSK (without gemfile by default) it fails on "bundle install".

Fix it checking that gemfile is available before running the command.